### PR TITLE
feat(All - Content Blocker): Add `Block ads, trackers, and analytics` patch

### DIFF
--- a/patches/api/patches.api
+++ b/patches/api/patches.api
@@ -2,6 +2,18 @@ public final class dev/jkcarino/revanced/patches/all/contentblocker/ads/DisableM
 	public static final fun getDisableMobileAdsPatch ()Lapp/revanced/patcher/patch/BytecodePatch;
 }
 
+public final class dev/jkcarino/revanced/patches/all/contentblocker/hosts/HostBlocker {
+	public fun <init> ()V
+	public final fun clear ()V
+	public final fun extractHost (Ljava/lang/String;)Ljava/lang/String;
+	public final fun isBlocked (Ljava/lang/String;)Z
+	public final fun parse (Ljava/io/File;)V
+}
+
+public final class dev/jkcarino/revanced/patches/all/contentblocker/hosts/HostsBlockerPatchKt {
+	public static final fun getHostsBlockerPatch ()Lapp/revanced/patcher/patch/BytecodePatch;
+}
+
 public final class dev/jkcarino/revanced/patches/all/detection/signature/pms/BypassSignatureChecksPatchKt {
 	public static final fun getBypassSignatureChecksPatch ()Lapp/revanced/patcher/patch/BytecodePatch;
 }
@@ -87,6 +99,7 @@ public final class dev/jkcarino/revanced/util/BytecodeUtilsKt {
 	public static final fun containsLiteralInstruction (Lcom/android/tools/smali/dexlib2/iface/Method;J)Z
 	public static final fun filterMethods (Lcom/android/tools/smali/dexlib2/iface/ClassDef;Lkotlin/jvm/functions/Function2;)Ljava/util/List;
 	public static final fun filterMethods (Ljava/util/List;Lkotlin/jvm/functions/Function2;)Ljava/util/List;
+	public static final fun findMutableFieldOf (Lapp/revanced/patcher/util/proxy/mutableTypes/MutableClass;Lcom/android/tools/smali/dexlib2/iface/Field;)Lapp/revanced/patcher/util/proxy/mutableTypes/MutableField;
 	public static final fun findMutableMethodOf (Lapp/revanced/patcher/util/proxy/mutableTypes/MutableClass;Lcom/android/tools/smali/dexlib2/iface/Method;)Lapp/revanced/patcher/util/proxy/mutableTypes/MutableMethod;
 	public static final fun indexOfFirstLiteralInstruction (Lcom/android/tools/smali/dexlib2/iface/Method;J)I
 	public static final fun literal (Lapp/revanced/patcher/FingerprintBuilder;Lkotlin/jvm/functions/Function0;)V
@@ -106,5 +119,10 @@ public final class dev/jkcarino/revanced/util/ResourceUtilsKt {
 	public static final fun get (Lorg/w3c/dom/Element;Ljava/lang/String;)Ljava/lang/String;
 	public static final fun removeElements (Lorg/w3c/dom/Node;Ljava/util/List;)V
 	public static final fun set (Lorg/w3c/dom/Element;Ljava/lang/String;Ljava/lang/String;)V
+}
+
+public final class dev/jkcarino/revanced/util/transformation/TransformationPatchKt {
+	public static final fun transformationPatch (Lapp/revanced/patcher/patch/BytecodePatchContext;Lcom/android/tools/smali/dexlib2/iface/ClassDef;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function2;)V
+	public static synthetic fun transformationPatch$default (Lapp/revanced/patcher/patch/BytecodePatchContext;Lcom/android/tools/smali/dexlib2/iface/ClassDef;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
 }
 

--- a/patches/src/main/kotlin/dev/jkcarino/revanced/patches/all/contentblocker/hosts/HostBlocker.kt
+++ b/patches/src/main/kotlin/dev/jkcarino/revanced/patches/all/contentblocker/hosts/HostBlocker.kt
@@ -1,0 +1,93 @@
+package dev.jkcarino.revanced.patches.all.contentblocker.hosts
+
+import java.io.File
+import java.net.URI
+
+class HostBlocker {
+    private val blockedHosts = hashSetOf<String>()
+
+    private fun processLine(line: String) {
+        val trimmed = line
+            .substringBefore(COMMENT_CHAR)
+            .trim()
+
+        if (trimmed.isEmpty()) return
+
+        val host = trimmed
+            .substringAfter(SPACE_CHAR)
+            .trim()
+
+        if (host in RESERVED_HOSTNAMES) return
+
+        val normalizedHost = normalizeHost(host)
+        if (normalizedHost != null) {
+            blockedHosts.add(normalizedHost)
+        }
+    }
+
+    private fun normalizeHost(input: String): String? {
+        if (input.isEmpty() || input.length > MAX_DOMAIN_LENGTH) return null
+
+        val host = runCatching { extractHost(input) }
+            .getOrNull()
+            ?: return null
+
+        if (host.length > MAX_DOMAIN_LENGTH
+            || host.startsWith(DOT_CHAR)
+            || host.endsWith(DOT_CHAR)
+        ) return null
+
+        val parts = host.split(DOT_CHAR)
+        if (parts.size < MIN_PARTS || parts.size > MAX_PARTS) return null
+
+        for (part in parts) {
+            if (part.length > MAX_PARTS_LENGTH) return null
+        }
+
+        return host.lowercase()
+    }
+
+    fun parse(file: File) {
+        file.forEachLine { line ->
+            processLine(line)
+        }
+    }
+
+    fun extractHost(input: String): String {
+        val urlWithScheme = if (input.contains("://")) input else "http://$input"
+        val host = URI.create(urlWithScheme).host
+        return host
+    }
+
+    fun isBlocked(input: String): Boolean {
+        val normalizedHost = normalizeHost(input)
+        return normalizedHost != null && blockedHosts.contains(normalizedHost)
+    }
+
+    fun clear() {
+        blockedHosts.clear()
+    }
+
+    private companion object {
+        private const val COMMENT_CHAR = '#'
+        private const val SPACE_CHAR = ' '
+        private const val DOT_CHAR = '.'
+        private const val MAX_DOMAIN_LENGTH = 253
+        private const val MAX_PARTS_LENGTH = 63
+        private const val MIN_PARTS = 2
+        private const val MAX_PARTS = 127
+        private val RESERVED_HOSTNAMES = setOf(
+            "localhost",
+            "localhost.localdomain",
+            "local",
+            "broadcasthost",
+
+            // IPv4
+            "127.0.0.1",
+            "0.0.0.0",
+
+            // IPv6
+            "::1",
+        )
+    }
+}

--- a/patches/src/main/kotlin/dev/jkcarino/revanced/patches/all/contentblocker/hosts/HostsBlockerPatch.kt
+++ b/patches/src/main/kotlin/dev/jkcarino/revanced/patches/all/contentblocker/hosts/HostsBlockerPatch.kt
@@ -1,0 +1,133 @@
+package dev.jkcarino.revanced.patches.all.contentblocker.hosts
+
+import app.revanced.patcher.extensions.InstructionExtensions.getInstruction
+import app.revanced.patcher.extensions.InstructionExtensions.replaceInstruction
+import app.revanced.patcher.patch.bytecodePatch
+import app.revanced.patcher.patch.stringOption
+import app.revanced.patcher.util.proxy.mutableTypes.encodedValue.MutableStringEncodedValue
+import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.reference.StringReference
+import com.android.tools.smali.dexlib2.iface.value.StringEncodedValue
+import com.android.tools.smali.dexlib2.immutable.value.ImmutableStringEncodedValue
+import dev.jkcarino.revanced.util.getEncodedValue
+import dev.jkcarino.revanced.util.getReference
+import dev.jkcarino.revanced.util.transformation.transformationPatch
+import java.io.File
+import java.util.logging.Logger
+
+@Suppress("unused")
+val hostsBlockerPatch = bytecodePatch(
+    name = "Block ads, trackers, and analytics",
+    description = "Blocks ads, trackers, analytics, and unwanted content in apps and games using a hosts file.",
+    use = false
+) {
+    val logger = Logger.getLogger(this::class.java.name)
+
+    val hostsOption by stringOption(
+        key = "hosts",
+        default = null,
+        title = "Hosts file",
+        description = "The hosts file containing hosts or domains you want to block, one per line.",
+        required = true
+    ) { filePath ->
+        !filePath.isNullOrEmpty() && File(filePath.trim()).isFile
+    }
+
+    val redirectionIpOption by stringOption(
+        key = "redirectionIp",
+        title = "Redirection IP",
+        default = "0.0.0.0",
+        values = mapOf(
+            "Default" to "0.0.0.0",
+            "localhost" to "127.0.0.1"
+        ),
+        description = "The IP address to redirect blocked domains to. " +
+            "This will be used with your hosts list to block content.",
+        required = true
+    ) { ipAddress ->
+        // Basic validation but this doesn't validate whether the IP address is valid
+        val ipAddressPattern = """^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$""".toRegex()
+        !ipAddress.isNullOrEmpty() && ipAddress.matches(ipAddressPattern)
+    }
+
+    execute {
+        val hostsFile = File(hostsOption!!.trim())
+        val redirectionIp = redirectionIpOption!!
+        val blockedHosts = mutableSetOf<String>()
+        val hostBlocker = HostBlocker()
+
+        hostBlocker.parse(hostsFile)
+
+        transformationPatch(
+            fieldFilter = fieldFilter@{ _, field ->
+                val encodedValue = field
+                    .getEncodedValue<StringEncodedValue>()
+                    ?: return@fieldFilter false
+                val fieldValue = encodedValue.value
+
+                hostBlocker.isBlocked(fieldValue)
+            },
+            fieldTransform = fieldTransform@{ mutableField, _ ->
+                val fieldValue = mutableField
+                    .getEncodedValue<StringEncodedValue>()!!
+                    .value
+
+                val blockedHost = hostBlocker
+                    .extractHost(fieldValue)
+                    .also(blockedHosts::add)
+
+                val updatedHost = fieldValue.replace(
+                    oldValue = blockedHost,
+                    newValue = redirectionIp,
+                    ignoreCase = true
+                )
+
+                mutableField.initialValue = MutableStringEncodedValue(
+                    ImmutableStringEncodedValue(updatedHost)
+                )
+            },
+            methodFilter = filter@{ _, _, instruction, instructionIndex ->
+                val reference = instruction
+                    .getReference<StringReference>()
+                    ?: return@filter null
+                val string = reference.string
+
+                if (!hostBlocker.isBlocked(string)) {
+                    return@filter null
+                }
+
+                instructionIndex to string
+            },
+            methodTransform = { mutableMethod, entry ->
+                val (index, string) = entry
+                val register = mutableMethod
+                    .getInstruction<OneRegisterInstruction>(index)
+                    .registerA
+
+                val blockedHost = hostBlocker
+                    .extractHost(string)
+                    .also(blockedHosts::add)
+
+                val updatedHost = string.replace(
+                    oldValue = blockedHost,
+                    newValue = redirectionIp,
+                    ignoreCase = true
+                )
+
+                mutableMethod.replaceInstruction(
+                    index = index,
+                    smaliInstruction = """
+                        const-string v$register, "$updatedHost"
+                    """
+                )
+            }
+        )
+
+        blockedHosts.forEach { host ->
+            logger.info("[Found] $host blocked.")
+        }
+
+        hostBlocker.clear()
+        blockedHosts.clear()
+    }
+}

--- a/patches/src/main/kotlin/dev/jkcarino/revanced/util/BytecodeUtils.kt
+++ b/patches/src/main/kotlin/dev/jkcarino/revanced/util/BytecodeUtils.kt
@@ -9,11 +9,13 @@ import app.revanced.patcher.util.proxy.ClassProxy
 import app.revanced.patcher.util.proxy.mutableTypes.MutableClass
 import app.revanced.patcher.util.proxy.mutableTypes.MutableMethod
 import com.android.tools.smali.dexlib2.iface.ClassDef
+import com.android.tools.smali.dexlib2.iface.Field
 import com.android.tools.smali.dexlib2.iface.Method
 import com.android.tools.smali.dexlib2.iface.instruction.Instruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.WideLiteralInstruction
 import com.android.tools.smali.dexlib2.iface.reference.Reference
+import com.android.tools.smali.dexlib2.iface.value.EncodedValue
 import com.android.tools.smali.dexlib2.util.MethodUtil
 
 /**
@@ -27,6 +29,13 @@ fun MutableClass.transformMethods(transform: MutableMethod.() -> MutableMethod) 
     val transformedMethods = methods.map { it.transform() }
     methods.clear()
     methods.addAll(transformedMethods)
+}
+
+/**
+ * Finds and returns the first matching field in the class that matches the given [field].
+ */
+fun MutableClass.findMutableFieldOf(field: Field) = this.fields.first {
+    it.name == field.name && it.type == field.type
 }
 
 /**
@@ -85,6 +94,12 @@ fun Method.containsLiteralInstruction(literal: Long) =
  */
 inline fun <reified T : Reference> Instruction.getReference() =
     (this as? ReferenceInstruction)?.reference as? T
+
+/**
+ * Returns the [Field]'s initial value as [T] or null if the initial value is not of type [T].
+ */
+inline fun <reified T : EncodedValue> Field.getEncodedValue() =
+    this.initialValue as? T
 
 /**
  * Traverses the class hierarchy starting from the given root [targetClass].

--- a/patches/src/main/kotlin/dev/jkcarino/revanced/util/transformation/TransformationPatch.kt
+++ b/patches/src/main/kotlin/dev/jkcarino/revanced/util/transformation/TransformationPatch.kt
@@ -1,0 +1,88 @@
+package dev.jkcarino.revanced.util.transformation
+
+import app.revanced.patcher.patch.BytecodePatchContext
+import app.revanced.patcher.util.proxy.mutableTypes.MutableField
+import app.revanced.patcher.util.proxy.mutableTypes.MutableMethod
+import com.android.tools.smali.dexlib2.iface.ClassDef
+import com.android.tools.smali.dexlib2.iface.Field
+import com.android.tools.smali.dexlib2.iface.Method
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction
+import dev.jkcarino.revanced.util.findMutableFieldOf
+import dev.jkcarino.revanced.util.findMutableMethodOf
+
+fun <T> BytecodePatchContext.transformationPatch(
+    classDef: ClassDef? = null,
+    fieldFilter: (ClassDef, Field) -> Boolean = { _, _ -> false },
+    fieldTransform: (MutableField, ClassDef) -> Unit = { _, _ -> },
+    methodFilter: (ClassDef, Method, Instruction, Int) -> T?,
+    methodTransform: (MutableMethod, T) -> Unit,
+) {
+    fun findPatchIndices(classDef: ClassDef, method: Method): Sequence<T>? =
+        method.implementation
+            ?.instructions
+            ?.asSequence()
+            ?.withIndex()
+            ?.mapNotNull { (index, instruction) ->
+                methodFilter(classDef, method, instruction, index)
+            }
+
+    fun ClassDef.filterMethods(): List<Method> = buildList {
+        methods.forEach { method ->
+            val patchIndices = findPatchIndices(
+                classDef = this@filterMethods,
+                method = method
+            )
+            if (patchIndices?.any() == true) {
+                add(method)
+            }
+        }
+    }
+
+    fun ClassDef.filterFields(): List<Field> = buildList {
+        fields.forEach { field ->
+            if (fieldFilter(this@filterFields, field)) {
+                add(field)
+            }
+        }
+    }
+
+    buildMap {
+        if (classDef != null) {
+            val methods = classDef.filterMethods()
+            val fields = classDef.filterFields()
+
+            if (methods.isNotEmpty() || fields.isNotEmpty()) {
+                put(classDef, methods to fields)
+            }
+            return@buildMap
+        }
+
+        classes.forEach { classDef ->
+            val methods = classDef.filterMethods()
+            val fields = classDef.filterFields()
+
+            if (methods.isNotEmpty() || fields.isNotEmpty()) {
+                put(classDef, methods to fields)
+            }
+        }
+    }.forEach { (classDef, pair) ->
+        val mutableClass = proxy(classDef).mutableClass
+        val (methods, fields) = pair
+
+        methods.forEach methods@{ method ->
+            val mutableMethod = mutableClass.findMutableMethodOf(method)
+            val patchIndices = findPatchIndices(mutableClass, mutableMethod)
+                ?.toCollection(ArrayDeque())
+                ?: return@methods
+
+            while (!patchIndices.isEmpty()) {
+                methodTransform(mutableMethod, patchIndices.removeLast())
+            }
+        }
+
+        fields.forEach { field ->
+            val mutableField = mutableClass.findMutableFieldOf(field)
+            fieldTransform(mutableField, classDef)
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces a universal `Block ads, trackers, and analytics` patch that enhances user privacy and improves the app experience by blocking known ad servers, trackers, and analytics domains using a hosts file.

**Supported formats:**

- `etc/hosts`-style syntax:
```
# This is a comment
0.0.0.0 example.com
0.0.0.0 test.example.com
```
- Domains-only syntax:
```
example.com
test.example.com
```