### PR TITLE
chore(All - Signature): Replace Bouncy Castle with Java's standard library

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,14 +1,5 @@
 [versions]
-bouncycastle = "1.79"
 revanced-patcher = "21.0.0"
-shadow = "9.0.0-beta4"
 # Tracking https://github.com/google/smali/issues/64.
 #noinspection GradleDependency
 smali = "3.0.5"
-
-[libraries]
-bouncycastle-pkix = { module = "org.bouncycastle:bcpkix-jdk18on", version.ref = "bouncycastle" }
-bouncycastle-provider = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bouncycastle" }
-
-[plugins]
-shadow = { id = "com.gradleup.shadow", version.ref = "shadow" }

--- a/patches/build.gradle.kts
+++ b/patches/build.gradle.kts
@@ -1,36 +1,8 @@
 group = "dev.jkcarino"
 
-plugins {
-    alias(libs.plugins.shadow)
-}
-
-dependencies {
-    implementation(libs.bouncycastle.pkix)
-    implementation(libs.bouncycastle.provider)
-}
-
 kotlin {
     compilerOptions {
         freeCompilerArgs = listOf("-Xcontext-receivers")
-    }
-}
-
-tasks {
-    shadowJar {
-        archiveClassifier = ""
-
-        manifest {
-            exclude("META-INF/versions/**")
-        }
-        dependencies {
-            include(dependency("org.bouncycastle:.*"))
-            relocate("org.bouncycastle", "shadow.org.bouncycastle")
-        }
-        minimize()
-    }
-
-    named("buildAndroid").configure {
-        dependsOn(shadowJar)
     }
 }
 


### PR DESCRIPTION
This removes the Bouncy Castle dependency by using Java's standard library for cert processing and encoding, significantly reducing the file size of the `rvp` output file from 3.4 MB to ~200 KB.