### PR TITLE
feat(All - Identify): Add `Spoof Advertising ID` patch

### DIFF
--- a/patches/api/patches.api
+++ b/patches/api/patches.api
@@ -50,6 +50,10 @@ public final class dev/jkcarino/revanced/patches/all/firebase/performance/Deacti
 	public static final fun getDeactivateFirebasePerfPatch ()Lapp/revanced/patcher/patch/ResourcePatch;
 }
 
+public final class dev/jkcarino/revanced/patches/all/misc/identity/advertising/SpoofAdvertisingIdPatchKt {
+	public static final fun getSpoofAdvertisingIdPatch ()Lapp/revanced/patcher/patch/BytecodePatch;
+}
+
 public final class dev/jkcarino/revanced/patches/all/misc/network/RemoveInternetPermissionPatchKt {
 	public static final fun getRemoveInternetPermissionPatch ()Lapp/revanced/patcher/patch/ResourcePatch;
 }

--- a/patches/src/main/kotlin/dev/jkcarino/revanced/patches/all/misc/identity/advertising/Fingerprints.kt
+++ b/patches/src/main/kotlin/dev/jkcarino/revanced/patches/all/misc/identity/advertising/Fingerprints.kt
@@ -1,0 +1,13 @@
+package dev.jkcarino.revanced.patches.all.misc.identity.advertising
+
+import app.revanced.patcher.fingerprint
+
+internal val getInfoInternalFingerprint = fingerprint {
+    returns("L")
+    strings(
+        "Calling this from your main thread can lead to deadlock",
+        "AdvertisingIdClient",
+        "GMS remote exception",
+        "Remote exception",
+    )
+}

--- a/patches/src/main/kotlin/dev/jkcarino/revanced/patches/all/misc/identity/advertising/SpoofAdvertisingIdPatch.kt
+++ b/patches/src/main/kotlin/dev/jkcarino/revanced/patches/all/misc/identity/advertising/SpoofAdvertisingIdPatch.kt
@@ -1,0 +1,60 @@
+package dev.jkcarino.revanced.patches.all.misc.identity.advertising
+
+import app.revanced.patcher.extensions.InstructionExtensions.getInstruction
+import app.revanced.patcher.extensions.InstructionExtensions.instructions
+import app.revanced.patcher.extensions.InstructionExtensions.replaceInstruction
+import app.revanced.patcher.patch.bytecodePatch
+import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import dev.jkcarino.revanced.util.getReference
+
+@Suppress("unused")
+val spoofAdvertisingIdPatch = bytecodePatch(
+    name = "Spoof Advertising ID",
+    description = "Spoofs the device's advertising ID with a string of zeros.",
+    use = false,
+) {
+    execute {
+        getInfoInternalFingerprint.method.apply {
+            val advertisingIdClientInfo = returnType
+            val advertisingIdClientInfoIndex = instructions
+                .last { instruction ->
+                    val reference = instruction
+                        .getReference<MethodReference>()
+                        ?: return@last false
+
+                    reference.definingClass == advertisingIdClientInfo
+                        && reference.name == "<init>"
+                        && reference.returnType == "V"
+                }
+                .location
+                .index
+
+            val targetRegister =
+                getInstruction<FiveRegisterInstruction>(advertisingIdClientInfoIndex)
+                    .registerD
+
+            val advertisingIdIndex = instructions
+                .take(advertisingIdClientInfoIndex)
+                .last { instruction ->
+                    val index = instruction.location.index
+                    val advertisingIdRegister =
+                        (getInstruction(index) as? OneRegisterInstruction)
+                            ?.registerA
+                            ?: return@last false
+
+                    advertisingIdRegister == targetRegister
+                }
+                .location
+                .index
+
+            replaceInstruction(
+                index = advertisingIdIndex,
+                smaliInstruction = """
+                    const-string v$targetRegister, "00000000-0000-0000-0000-000000000000"
+                """
+            )
+        }
+    }
+}


### PR DESCRIPTION
This implements spoofing of device's advertising ID, replacing it with a string of zeros (`00000000-0000-0000-0000-000000000000`). Tested on both obfuscated and non-obfuscated apps.